### PR TITLE
Fix: Remove deprecated name parameter from package dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Jounce/Surge", from: "2.3.0"),
-        .package(name: "Logging", url: "https://github.com/apple/swift-log", from: "1.5.4"),
-        .package(name: "LoggingFormatAndPipe", url: "https://github.com/Adorkable/swift-log-format-and-pipe", from: "0.1.1"),
-        .package(name: "GRDB", url: "https://github.com/groue/GRDB.swift", from: "7.1.0")
+        .package(url: "https://github.com/apple/swift-log", from: "1.5.4"),
+        .package(url: "https://github.com/Adorkable/swift-log-format-and-pipe", from: "0.1.1"),
+        .package(url: "https://github.com/groue/GRDB.swift", from: "7.1.0")
     ],
     targets: [
         .target(name: "LocoKit2", dependencies: ["Surge", "GRDB", "Logging", "LoggingFormatAndPipe"]),

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,12 @@ let package = Package(
         .package(url: "https://github.com/groue/GRDB.swift", from: "7.1.0")
     ],
     targets: [
-        .target(name: "LocoKit2", dependencies: ["Surge", "GRDB", "Logging", "LoggingFormatAndPipe"]),
+        .target(name: "LocoKit2", dependencies: [
+            "Surge",
+            .product(name: "GRDB", package: "GRDB.swift"),
+            .product(name: "Logging", package: "swift-log"),
+            .product(name: "LoggingFormatAndPipe", package: "swift-log-format-and-pipe")
+        ]),
         .testTarget(name: "LocoKit2Tests", dependencies: ["LocoKit2"])
     ]
 )


### PR DESCRIPTION
Nothing earth shattering here ... just a desire to remove the deprecated 'name:' parameter from package dependency declarations. Swift Package Manager now automatically infers package names from URLs.

Fixes deprecation warnings:
- 'package(name:url:from:)' is deprecated: use package(url:from:) instead