### PR TITLE
BIG-459: Restore Foursquare V2 category id to Place model + fix legac…

### DIFF
--- a/Sources/LocoKit2/Database/Database+DelayedMigrations.swift
+++ b/Sources/LocoKit2/Database/Database+DelayedMigrations.swift
@@ -270,5 +270,11 @@ extension Database {
                 END;
                 """)
         }
+
+        migrator.registerMigration("Place.foursquareCategoryV2Id") { db in
+            try? db.alter(table: "Place") { table in
+                table.add(column: "foursquareCategoryV2Id", .text)
+            }
+        }
     }
 }

--- a/Sources/LocoKit2/Database/Database+Schema.swift
+++ b/Sources/LocoKit2/Database/Database+Schema.swift
@@ -40,6 +40,7 @@ extension Database {
 
                 table.column("foursquarePlaceId", .text).indexed()
                 table.column("foursquareCategoryId", .integer)
+                table.column("foursquareCategoryV2Id", .text)
 
                 table.column("visitCount", .integer).notNull().indexed()
                 table.column("visitDays", .integer).notNull()

--- a/Sources/LocoKit2/ImportExport/ExportManager.swift
+++ b/Sources/LocoKit2/ImportExport/ExportManager.swift
@@ -19,7 +19,7 @@ public protocol ExportExtensionHandler: Sendable {
 
 @ImportExportActor
 public enum ExportManager {
-    public static let schemaVersion = "2.2.0"
+    public static let schemaVersion = "2.3.0"
 
     // MARK: - Export state
 

--- a/Sources/LocoKit2/ImportExport/OldLocoKitImporter.swift
+++ b/Sources/LocoKit2/ImportExport/OldLocoKitImporter.swift
@@ -116,6 +116,87 @@ public enum OldLocoKitImporter {
         }
     }
 
+    // MARK: - Backfills
+
+    /// One-shot backfill: copies `foursquareCategoryId` (Foursquare V2 string id) from
+    /// `ArcApp.sqlite` onto already-imported `Place` rows whose `foursquareCategoryV2Id`
+    /// is still NULL. Use this when an existing install has already run the legacy
+    /// import on a build that didn't preserve the field.
+    ///
+    /// No-op when `hasOldArcTimelineData` is false. Idempotent — only updates rows
+    /// where `Place.foursquareCategoryV2Id IS NULL`, matching on
+    /// `Place.id == LegacyPlace.placeId` AND
+    /// `Place.foursquarePlaceId == LegacyPlace.foursquareVenueId`.
+    ///
+    /// IMPORTANT: this library does not record whether the backfill has been run.
+    /// The calling app is responsible for tracking completion (e.g. via UserDefaults)
+    /// so it isn't re-run on every launch.
+    ///
+    /// - Returns: number of `Place` rows updated.
+    @discardableResult
+    public static func backfillFoursquareCategoryV2Id() async throws -> Int {
+        guard !importInProgress else {
+            throw ImportExportError.importAlreadyInProgress
+        }
+        guard hasOldArcTimelineData else { return 0 }
+        guard let appGroupDir = Database.highlander.appGroupDbDir else {
+            throw ImportExportError.databaseConnectionFailed
+        }
+
+        // claim the import slot so a concurrent startImport/resumeImport can't
+        // race us across await suspension points
+        importInProgress = true
+        defer { importInProgress = false }
+
+        let arcAppUrl = appGroupDir.appendingPathComponent("ArcApp.sqlite")
+
+        var arcConfig = Configuration()
+        arcConfig.readonly = true
+        let arcPool = try DatabasePool(path: arcAppUrl.path, configuration: arcConfig)
+
+        Log.info("Starting foursquareCategoryV2Id backfill", subsystem: .importing)
+        let start = Date()
+
+        let legacyPlaces = try await arcPool.read { db in
+            guard try db.tableExists("Place"),
+                  try db.columns(in: "Place").contains(where: { $0.name == "foursquareCategoryId" }) else {
+                return [LegacyPlace]()
+            }
+            return try LegacyPlace
+                .filter(LegacyPlace.Columns.foursquareCategoryId != nil)
+                .filter(LegacyPlace.Columns.foursquareVenueId != nil)
+                .fetchAll(db)
+        }
+
+        let batchSize = 500
+        let batches = legacyPlaces.chunked(into: batchSize)
+        var updateCount = 0
+
+        for batch in batches {
+            let batchUpdated = try await Database.pool.write { db -> Int in
+                var localCount = 0
+                for lp in batch {
+                    guard let categoryId = lp.foursquareCategoryId,
+                          let venueId = lp.foursquareVenueId else { continue }
+                    try db.execute(sql: """
+                        UPDATE Place
+                        SET foursquareCategoryV2Id = ?
+                        WHERE id = ?
+                          AND foursquarePlaceId = ?
+                          AND foursquareCategoryV2Id IS NULL
+                        """, arguments: [categoryId, lp.placeId, venueId])
+                    localCount += db.changesCount
+                }
+                return localCount
+            }
+            updateCount += batchUpdated
+        }
+
+        Log.info("foursquareCategoryV2Id backfill: updated \(updateCount) places (of \(legacyPlaces.count) candidates) in \(String(format: "%.1f", -start.timeIntervalSinceNow))s", subsystem: .importing)
+
+        return updateCount
+    }
+
     // MARK: - Private helpers
 
     private static func performImportPhases(

--- a/Sources/LocoKit2/Models/Legacy/LegacyPlace.swift
+++ b/Sources/LocoKit2/Models/Legacy/LegacyPlace.swift
@@ -30,6 +30,7 @@ public struct LegacyPlace: FetchableRecord, TableRecord, Codable, Hashable, Send
     public var googlePrimaryType: String?
     
     public var foursquareVenueId: String?
+    public var foursquareCategoryId: String?
     public var foursquareCategoryIntId: Int?
     
     public var coordinate: CLLocationCoordinate2D {
@@ -53,6 +54,7 @@ public struct LegacyPlace: FetchableRecord, TableRecord, Codable, Hashable, Send
         public static let googlePlaceId = Column("googlePlaceId")
         public static let googlePrimaryType = Column("googlePrimaryType")
         public static let foursquareVenueId = Column("foursquareVenueId")
+        public static let foursquareCategoryId = Column("foursquareCategoryId")
         public static let foursquareCategoryIntId = Column("foursquareCategoryIntId")
     }
 }

--- a/Sources/LocoKit2/Models/Legacy/Place+Legacy.swift
+++ b/Sources/LocoKit2/Models/Legacy/Place+Legacy.swift
@@ -28,5 +28,8 @@ extension Place {
         self.radiusMean = legacyPlace.radiusMean
         self.radiusSD = legacyPlace.radiusSD
         self.source = "LocoKit"
+        // LegacyPlace.foursquareCategoryId is Arc's Foursquare V2 string id;
+        // Place.foursquareCategoryId (Int?) is the unrelated V3 numeric id.
+        self.foursquareCategoryV2Id = legacyPlace.foursquareCategoryId
     }
 }

--- a/Sources/LocoKit2/Models/Place.swift
+++ b/Sources/LocoKit2/Models/Place.swift
@@ -39,6 +39,10 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
     public var googlePrimaryType: String?
     public var foursquarePlaceId: String?
     public var foursquareCategoryId: Int?
+    // Foursquare V2 string category id (e.g. "4bf58dd8d48988d116941735").
+    // Populated only for places imported from pre-AT4 Arc history; null for all
+    // new places since the Foursquare V2 API is deprecated.
+    public var foursquareCategoryV2Id: String?
 
     public var rtreeId: Int64?
     
@@ -238,6 +242,7 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
         case googlePrimaryType
         case foursquarePlaceId
         case foursquareCategoryId
+        case foursquareCategoryV2Id
 
         case visitCount
         case visitDays
@@ -268,6 +273,7 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
         public static let googlePrimaryType = Column(CodingKeys.googlePrimaryType)
         public static let foursquarePlaceId = Column(CodingKeys.foursquarePlaceId)
         public static let foursquareCategoryId = Column(CodingKeys.foursquareCategoryId)
+        public static let foursquareCategoryV2Id = Column(CodingKeys.foursquareCategoryV2Id)
         public static let visitCount = Column(CodingKeys.visitCount)
         public static let visitDays = Column(CodingKeys.visitDays)
         public static let lastVisitDate = Column(CodingKeys.lastVisitDate)
@@ -283,7 +289,7 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
             id, lastSaved, source, latitude, longitude, radiusMean, radiusSD,
             secondsFromGMT, name, streetAddress, countryCode, locality, isStale,
             rtreeId, mapboxPlaceId, mapboxCategory, mapboxMakiIcon, googlePlaceId,
-            googlePrimaryType, foursquarePlaceId, foursquareCategoryId,
+            googlePrimaryType, foursquarePlaceId, foursquareCategoryId, foursquareCategoryV2Id,
             visitCount, visitDays, lastVisitDate
         ]
     }
@@ -318,6 +324,7 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
         googlePrimaryType = try container.decodeIfPresent(String.self, forKey: .googlePrimaryType)
         foursquarePlaceId = try container.decodeIfPresent(String.self, forKey: .foursquarePlaceId)
         foursquareCategoryId = try container.decodeIfPresent(Int.self, forKey: .foursquareCategoryId)
+        foursquareCategoryV2Id = try container.decodeIfPresent(String.self, forKey: .foursquareCategoryV2Id)
         
         // stats
         visitCount = try container.decodeIfPresent(Int.self, forKey: .visitCount) ?? 0
@@ -358,6 +365,7 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
         googlePrimaryType = row["googlePrimaryType"]
         foursquarePlaceId = row["foursquarePlaceId"]
         foursquareCategoryId = row["foursquareCategoryId"]
+        foursquareCategoryV2Id = row["foursquareCategoryV2Id"]
 
         // stats
         visitCount = row["visitCount"]
@@ -408,6 +416,7 @@ public struct Place: FetchableRecord, PersistableRecord, Identifiable, Codable, 
         container["googlePrimaryType"] = googlePrimaryType
         container["foursquarePlaceId"] = foursquarePlaceId
         container["foursquareCategoryId"] = foursquareCategoryId
+        container["foursquareCategoryV2Id"] = foursquareCategoryV2Id
 
         // stats
         container["visitCount"] = visitCount

--- a/docs/export/FORMAT.md
+++ b/docs/export/FORMAT.md
@@ -1,13 +1,14 @@
 # LocoKit2 Export Format Specification
 
 ## Version
-- Current schema version: 2.2.0
+- Current schema version: 2.3.0
 - Uses semantic versioning (major.minor.patch)
 - Major version changes indicate breaking format changes
 - Minor versions add features in a backward-compatible way
 - Patch versions make backward-compatible fixes
 
 ### Version History
+- **2.3.0**: Added `Place.foursquareCategoryV2Id` (legacy Foursquare V2 string category id, restored for places carried over from pre-AT4 Arc history)
 - **2.2.0**: Added gzip compression for sample files (samples/*.json.gz)
 - **2.1.0**: Changed date encoding from numeric (seconds since reference date) to ISO8601 strings
 - **2.0.0**: Initial LocoKit2 export format
@@ -44,7 +45,7 @@ metadata.json:
 ```json
 {
   "exportId": "A1B2C3D4-...",   // Unique identifier for this export session (used for resume validation)
-  "schemaVersion": "2.2.0",     // Semantic version of export format
+  "schemaVersion": "2.3.0",     // Semantic version of export format
   "exportMode": "bucketed",     // "bucketed" (only supported mode currently)
   "exportType": "full",         // "full" or "incremental" (only valid values)
 
@@ -173,7 +174,8 @@ Session completion flags (`itemsCompleted`, etc) indicate whether all qualifying
   googlePlaceId: string | null
   googlePrimaryType: string | null
   foursquarePlaceId: string | null
-  foursquareCategoryId: number | null
+  foursquareCategoryId: number | null     // Foursquare V3 numeric category id
+  foursquareCategoryV2Id: string | null   // Foursquare V2 string category id 
 }
 ```
 


### PR DESCRIPTION
BIG-459: Restore Foursquare V2 category id to Place model + fix legacy import

AT4 deliberately dropped the Foursquare V2 string category id
(`foursquareCategoryId`) from the schema on the grounds that Foursquare
v2 was already deprecated. The V3 numeric id (`foursquareCategoryIntId`)
was carried over; the V2 string was not.

The field loss surfaces as missing category icons across the majority of
Places for users with mature Arc histories: Yinon's data shows ~62%
Foursquare-derived, of which ~95%+ are V2-API-era — so roughly 59% of
his total Place list lost icons in the migration. Likely representative
of most paying/beta users.

This PR reconsiders that call and restores the field as
`foursquareCategoryV2Id: String?` on the Place model. The V2 suffix
disambiguates from `foursquareCategoryId: Int?` (the unrelated V3
numeric field that was kept).

**Schema + migration**
- `foursquareCategoryV2Id TEXT` added to `addInitialSchema` for
  fresh installs and as a `Place.foursquareCategoryV2Id` delayed
  migration for existing users (same try?/dual-registration pattern
  used by Place.source, Place.lastVisitDate, etc.)
- `LegacyPlace` now models the missing `foursquareCategoryId` column
  from ArcApp.sqlite; `Place(from:)` maps it to `foursquareCategoryV2Id`
  so future `OldLocoKitImporter` runs carry the field forward

**Already-migrated users**
Users who ran the legacy import on a build that predates this fix won't
benefit from the import-path fix alone. `OldLocoKitImporter` gains a new
public `backfillFoursquareCategoryV2Id()` function for this cohort: reads
ArcApp.sqlite (gated on `hasOldArcTimelineData`), matches on
Place.id + foursquarePlaceId, and updates rows where
foursquareCategoryV2Id IS NULL. Idempotent; completion tracking is the
caller's responsibility (UserDefaults flag recommended).

The field will be null for all new places going forward — Foursquare V2
API is deprecated and no new places will be created with V2 data. It is
effectively read-only after legacy import.

Note: this PR covers the LocoKit2 side only. The Arc app still needs to
call `backfillFoursquareCategoryV2Id()` once per install and update icon
display logic to read `foursquareCategoryV2Id`.

## Caveats

1. **ArcApp schema is assumed**: I don't have access to an old Arc App export, so the schema assumptions about Place.foursquareCategoryId (Foursquare V2 string id) vs Place.foursquareCategoryIntId (V3 numeric id) in ArcApp.sqlite are based solely on the public ArcMini repo, which is old and may not reflect the current Arc V3 schema. The LegacyPlace decoding and the backfill's column mapping both rest on this assumption.
2. **Needs to be verified**: I can't run this myself because I don't have access to the Arc v3 Database directly. Before this ships to users, please run backfillFoursquareCategoryV2Id() against a real ArcApp.sqlite and confirm the resulting foursquareCategoryV2Id values look like Foursquare V2 category strings (e.g. 4bf58dd8d48988d116941735).
3. **Required Arc App changes**: This PR only covers the LocoKit2 side. The Arc app needs to (1) call OldLocoKitImporter.backfillFoursquareCategoryV2Id() once per install (perhaps gated on a UserDefaults flag, since the library doesn't track completion)
4. **Alternative implementation**: move the backfill into Database+DelayedMigrations.swift as a one-shot migration. That would remove the caller-tracking requirement entirely (the migrator already records which migrations have run) and make the fix self-contained on the LocoKit2 side. The tradeoff is that it's heavier than the typical migration in that file — it opens a second database (ArcApp.sqlite), reads from it, and writes a per-row UPDATE loop — whereas the existing migrations are mostly schema-level ALTER TABLE / index creation. Happy to refactor to that approach if you'd prefer the self-contained version.
5. **Missing icons not addressed**: This wouldn't fix the missing place category icons in Arc V4 discussed in BIG-459 directly, but it's a required stepping stone. I'll follow up with some strategies for this.